### PR TITLE
Make stop action safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ jobs:
       - run: echo '${{ matrix.message }}'
 
   stop-runner:
+    if: always()
     needs: [start-runner, complex-build]
-    if: always() && needs.start-runner.result == 'success'
     runs-on: ubuntu-20.04
     steps:
       - name: Stop runner

--- a/start/action.yml
+++ b/start/action.yml
@@ -78,6 +78,8 @@ runs:
 
         instance_id="$(aws ec2 run-instances --launch-template "$LAUNCH_TEMPLATE" --user-data "$user_data" | jq -r .Instances[0].InstanceId)"
 
+        echo "::set-output name=instance-id::$instance_id"
+
         echo "Started EC2 instance: $instance_id"
 
         echo "Waiting for repository runner to be registered ..."
@@ -97,11 +99,9 @@ runs:
             aws ec2 terminate-instances --instance-ids "$instance_id"
             exit 1
         else
+            echo "::set-output name=runner-id::$runner_id"
             echo "Repository runner registered with id: $runner_id"
         fi
-
-        echo "::set-output name=runner-id::$runner_id"
-        echo "::set-output name=instance-id::$instance_id"
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}

--- a/start/action.yml
+++ b/start/action.yml
@@ -100,7 +100,7 @@ runs:
             exit 1
         else
             echo "::set-output name=runner-id::$runner_id"
-            echo "Repository runner registered with id: $runner_id"
+            echo "Repository runner started (ID: $runner_id)"
         fi
       env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/start/action.yml
+++ b/start/action.yml
@@ -42,7 +42,7 @@ outputs:
     description: GitHub repository runner id
     value: ${{ steps.main.outputs.runner-id }}
   instance-id:
-    description: EC2 instance id
+    description: AWS EC2 instance id
     value: ${{ steps.main.outputs.instance-id }}
 
 runs:

--- a/stop/action.yml
+++ b/stop/action.yml
@@ -53,6 +53,7 @@ runs:
             echo "Deregistering GitHub repository runner: $RUNNER_ID ..."
             gh api -X DELETE -H 'Accept: application/vnd.github.v3+json' \
               "repos/$GITHUB_REPO/actions/runners/$RUNNER_ID" || echo "WARN: Failed to deregister GitHub repository runner (GitHub API call failed)"
+              
         fi
         
         # Failure to terminate the EC2 instance will incur unnecessary costs, so we fail loudly to ensure the user notices it
@@ -62,6 +63,7 @@ runs:
         else
             echo "Terminating EC2 instance: $INSTANCE_ID ..."
             aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" > /dev/null
+            echo "Repository runner stopped"
         fi
       env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/stop/action.yml
+++ b/stop/action.yml
@@ -46,16 +46,23 @@ runs:
     - id: main
       shell: bash
       run: |
-        echo "Deregistering repository runner: $RUNNER_ID ..."
+        # Offline runners are automatically deleted after 30 days, so we only emit a warning for runner deregistration failure
+        if [ -z "$RUNNER_ID" ]; then
+            echo "WARN: Unable to deregister GitHub repository runner (runner ID not available)
+        else
+            echo "Deregistering GitHub repository runner: $RUNNER_ID ..."
+            gh api -X DELETE -H 'Accept: application/vnd.github.v3+json' \
+              "repos/$GITHUB_REPO/actions/runners/$RUNNER_ID" || echo "WARN: Failed to deregister GitHub repository runner (GitHub API call failed)"
+        fi
         
-        gh api -X DELETE -H 'Accept: application/vnd.github.v3+json' \
-          "repos/$GITHUB_REPO/actions/runners/$RUNNER_ID" || echo "WARN: Failed to deregister runner"
-        
-        echo "Terminating EC2 instance: $INSTANCE_ID ..."
-        
-        aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" > /dev/null
-        
-        echo "Repository runner stopped"
+        # Failure to terminate the EC2 instance will incur unnecessary costs, so we fail loudly to ensure the user notices it
+        if [ -z "$INSTANCE_ID" ]; then
+            echo "ERROR: Unable to terminate EC2 instance (instance ID not available)
+            exit 1
+        else
+            echo "Terminating EC2 instance: $INSTANCE_ID ..."
+            aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" > /dev/null
+        fi
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}

--- a/stop/action.yml
+++ b/stop/action.yml
@@ -53,7 +53,6 @@ runs:
             echo "Deregistering GitHub repository runner: $RUNNER_ID ..."
             gh api -X DELETE -H 'Accept: application/vnd.github.v3+json' \
               "repos/$GITHUB_REPO/actions/runners/$RUNNER_ID" || echo "WARN: Failed to deregister GitHub repository runner (GitHub API call failed)"
-              
         fi
         
         # Failure to terminate the EC2 instance will incur unnecessary costs, so we fail the job to ensure the user notices

--- a/stop/action.yml
+++ b/stop/action.yml
@@ -48,7 +48,7 @@ runs:
       run: |
         # Offline runners are automatically deleted after 30 days, so we emit a warning for runner deregistration failure
         if [ -z "$RUNNER_ID" ]; then
-            echo "WARN: Unable to deregister GitHub repository runner (runner ID not available)
+            echo "WARN: Unable to deregister GitHub repository runner (runner ID not available)"
         else
             echo "Deregistering GitHub repository runner: $RUNNER_ID ..."
             gh api -X DELETE -H 'Accept: application/vnd.github.v3+json' \
@@ -57,7 +57,7 @@ runs:
         
         # Failure to terminate the EC2 instance will incur unnecessary costs, so we fail the job to ensure the user notices
         if [ -z "$INSTANCE_ID" ]; then
-            echo "ERROR: Unable to terminate EC2 instance (instance ID not available)
+            echo "ERROR: Unable to terminate EC2 instance (instance ID not available)"
             exit 1
         else
             echo "Terminating EC2 instance: $INSTANCE_ID ..."

--- a/stop/action.yml
+++ b/stop/action.yml
@@ -46,7 +46,7 @@ runs:
     - id: main
       shell: bash
       run: |
-        # Offline runners are automatically deleted after 30 days, so we only emit a warning for runner deregistration failure
+        # Offline runners are automatically deleted after 30 days, so we emit a warning for runner deregistration failure
         if [ -z "$RUNNER_ID" ]; then
             echo "WARN: Unable to deregister GitHub repository runner (runner ID not available)
         else
@@ -56,7 +56,7 @@ runs:
               
         fi
         
-        # Failure to terminate the EC2 instance will incur unnecessary costs, so we fail loudly to ensure the user notices it
+        # Failure to terminate the EC2 instance will incur unnecessary costs, so we fail the job to ensure the user notices
         if [ -z "$INSTANCE_ID" ]; then
             echo "ERROR: Unable to terminate EC2 instance (instance ID not available)
             exit 1


### PR DESCRIPTION
This might help in situations where the start job is cancelled, making the stop job more likely to successfully terminate the instance